### PR TITLE
The secret word is a list of words instead of a single word

### DIFF
--- a/hangPy.py
+++ b/hangPy.py
@@ -19,7 +19,6 @@ def main():
 
     secret_word = choice(word_list[difficulty])
     guessed_letters = set()  # Set to store guessed letters
-    secret_word = get_random_word(word_list)
     attempts = 0  # Number of attempts
     game_won = False  # Boolean to check if game is won
 


### PR DESCRIPTION
## Bug Description
The secret word is being set to a list of words insead of a single word

## Root Cause
The variable secret_word was being overwritten by an old declaration created before there were several difficulty levels in the dictionary word_list

## Solution Description
The second declaration has been removed.